### PR TITLE
fix pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - '.'
   - 'test-ember-app'


### PR DESCRIPTION
it turns out that our pnpm-workspace definition doesn't know about the "root package" 🙈 this PR fixes that