### PR TITLE
Show stack on error.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -36,6 +36,6 @@ ${formatResults(results)}
   process.exit(0);
 } catch (err) {
   console.error("Measurement failed");
-  console.error(err.stack);
+  console.error(err);
   process.exit(1);
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,6 +35,7 @@ ${formatResults(results)}
   );
   process.exit(0);
 } catch (err) {
-  console.error("Measurement failed:", err.message);
+  console.error("Measurement failed");
+  console.error(err.stack);
   process.exit(1);
 }


### PR DESCRIPTION
Before:
```bash
[Server] Funnel (5741) | 2903ms (0 ms)
[Server] Babel: @html-next/vertical-collection (271) | 2044ms (7 ms)
Performance measurement failed:
[Server]  ELIFECYCLE  Command failed.
Measurement failed: Server start timeout
```

After:
```bash
[Server] Babel: @html-next/vertical-collection (271) | 2044ms (7 ms)
Performance measurement failed:
[Server]  ELIFECYCLE  Command failed.
Measurement failed
Error: Server start timeout
    at Timeout._onTimeout (file://🏠/Development/OpenSource/build-start-rebuild-perf/lib/server.js:36:14)
    at listOnTimeout (node:internal/timers:608:17)
    at process.processTimers (node:internal/timers:543:7)
```

I now know to continue my debugging journey over in lib/server.js:36 -- which, lead me to find out that the timeout is only 2 minutes. This is not long enough. But that's an issue for later.