### PR TITLE
Disable thousands separator for clearness

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm dlx build-start-rebuild-perf --file "app/router.js" --wait-for ".logo"
 
 | Dev Server Ready | First Paint | App Loaded | Reload after change |
 | ---------------- | ----------- | ---------- | ------------------- |
-| 5,523 ms         | 5,618 ms    | 6,142 ms   | 918 ms              |
+| 5523 ms          | 5618 ms     | 6142 ms    | 918 ms              |
 ```
 
 ## Share with us

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,6 +38,7 @@ export class PrefixedTransform extends Transform {
 const formatter = Intl.NumberFormat("en-US", {
   style: "unit",
   unit: "millisecond",
+  useGrouping: false,
 });
 
 export function formatMs(timeMs) {


### PR DESCRIPTION
Number formatting is always such a mess because each language uses the same symbols for different things 🙈 For instance, in French,  space ` ` is the thousand separator, and comma `,` is the decimal separator.

The options we have to make the input easier to read are: 1. Use the system language by default instead of `'en-us'`, 2. Use a formatting without grouping.

Since this tool is engineer-oriented, I opted for the second solution; but open to hear your opinions if you see any drawbacks.