### PR TITLE
Fix waitForPageToLoad behavior

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -47,6 +47,32 @@ export async function initBrowser() {
   }
 }
 
+const HARD_CODED_NETWORK_IDLE_TIMEOUT = 30_000;
+async function waitForNetworkIdle(page, pageLoadTimeout) {
+  let attempts = Math.max(pageLoadTimeout / HARD_CODED_NETWORK_IDLE_TIMEOUT, 1);
+
+  /**
+   * waitForNetworkIdle has no configurable timeout
+   * and always times out at 30s, if your app takes
+   * more than 30s to finish dependency discovery and optimization.
+   * (easily possible on 3 million line code bases)
+   */
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    log(`waitForNetworkIdle: attempt ${attempt} of ${attempts}`);
+
+    try {
+      await page.waitForNetworkIdle();
+      return;
+    } catch (error) {
+      if (error.message.includes("Timed out after waiting 30000ms")) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+}
+
 export async function measurePageLoad(url, waitForSelector = "body", pageLoadTimeout = 60_000) {
   log(`Loading page: ${url}`);
 
@@ -62,7 +88,7 @@ export async function measurePageLoad(url, waitForSelector = "body", pageLoadTim
   const atFirstPaint = performance.now();
 
   log("Waiting for page to fully load...");
-  await page.waitForNetworkIdle();
+  await waitForNetworkIdle(page, pageLoadTimeout);
 
   log(`Waiting for element: ${waitForSelector}`);
   await page.waitForSelector(waitForSelector, {
@@ -80,7 +106,7 @@ export async function measurePageLoad(url, waitForSelector = "body", pageLoadTim
   };
 }
 
-export async function measureFileReload(filePath) {
+export async function measureFileReload(filePath, pageLoadTimeout = 60_000) {
   if (!filePath) {
     log("No file specified for reload test, skipping...");
     return 0;
@@ -106,7 +132,7 @@ export async function measureFileReload(filePath) {
   const atFileChanged = performance.now();
 
   log("Waiting for hot reload to complete...");
-  await page.waitForNetworkIdle();
+  await waitForNetworkIdle(page, pageLoadTimeout);
 
   const atReloadComplete = performance.now();
 

--- a/lib/measure.js
+++ b/lib/measure.js
@@ -33,7 +33,7 @@ export async function measure(options) {
       options.waitFor,
       options.pageLoadTimeout,
     );
-    const reloadMetrics = await measureFileReload(options.file);
+    const reloadMetrics = await measureFileReload(options.file, options.pageLoadTimeout);
     await terminateServer();
 
     return {


### PR DESCRIPTION
Previously this tool would timeout when waiting for dep optimization because pupeeteer's [waitForNetworkIdle](https://pptr.dev/api/puppeteer.waitfornetworkidleoptions) has no configurable timeout, and defaulted to 30s.


This PR implements a way to increase the timeout so that _large_ apps can do a cold/no-cache measurement with a wrapper-script such as what is below in the details.


Additionally, `measureFileReload` has to be aware of pageLoadTimeout as well, due to _reasons_, but can share code with initial page load, as we just wrap a puppeteer API.

<details><summary>essential script for reliably measuring vite perf</summary>

```bash
#!/usr/bin/env bash

echo "Measuring build perf of $(basename $PWD)"

# Set MEASURE_COLD=true to also check the cold-boot time without any caches
# Set TESTS=true to check how tests load instead of '/'
#
# Set LOCAL=./to/wherever/you/cloned/the/perf/code/locally
#
# Example
#
#   LOCAL=~/Development/OpenSource/build-start-rebuild-perf/bin/cli.js ./perf-check.sh
#
#   or
#
#   Local=1 ./perf-check.sh
#
#
#  (Setting to 1 means use this exact path)
#

TOOL="pnpm dlx build-start-rebuild-perf"

SELECTOR="[data-qid-application-wrapper]"
URL="/"

if [ "$TESTS" = "true" ]; then
	URL="/tests/index.html?file=models/user-test&hidepassed"
	SELECTOR="#qunit-testresult-display"
fi


if [[ -v LOCAL ]]; then
  if [[ "$LOCAL" == "1" ]]; then
    relative="Development/OpenSource/build-start-rebuild-perf/bin/cli.js"
    LOCAL="$HOME/$relative"
    echo "Using default location of ~/$relative"
  fi

  TOOL="node $LOCAL"
fi

port="41136"

# NOTE: must be logged out
common_args="\
  --timeout 1800000 \
  --page-load-timeout 1800000 \
  --file ./app/app.js \
  --wait-for '$SELECTOR' \
  --url 'https://localhost:$port$URL' \
  $@
"


local_run_force="./bin/setup-client && PROXY_STAGING=1 pnpm vite --force"
with_force="$TOOL --command '$local_run_force --port $port' $common_args"

local_run="./bin/setup-client && PROXY_STAGING=1  pnpm vite"
warm="$TOOL --command '$local_run --port $port' $common_args"

function preamble() {
	echo ""
	echo "Visiting: $URL"
	echo "Waiting for: $SELECTOR"
	echo ""
	echo "Running:"
	echo -e "$1"
	echo ""
	echo "If you want to this locally:"
	echo -e "\t$2"
	echo ""
}

if [[ "$MEASURE_COLD" == "true" ]]; then
	echo "No Cache"

	rm -rf node_modules/.vite
	rm -rf node_modules/.vite-temp
	rm -rf node_modules/.embroider

	preamble "$with_force" "$local_run_force"
	eval $with_force
fi

echo "Warm"

preamble "$warm" "$local_run"
eval $warm

```

</details>

---------------------------

How I tested locally:

```bash
# the above script creates and runs this command
node 🏠/Development/OpenSource/build-start-rebuild-perf/bin/cli.js \
  --command './bin/setup-client && PROXY_STAGING=1 pnpm vite --force --port 41136'   \
  --timeout 1800000   \
  --page-load-timeout 1800000   \
  --file ./app/app.js   \
  --wait-for '[data-qid-application-wrapper]'   \
  --url 'https://localhost:41136/'   \
  --log-level log
```
resulting in
```
# Cold
| Dev Server Ready | First Paint | App Loaded | Reload after change |
| ---------------- | ----------- | ---------- | ------------------- |
| 63285 ms         | 93024 ms    | 143825 ms  | 7946 ms             |

# Warm
| Dev Server Ready | First Paint | App Loaded | Reload after change |
| ---------------- | ----------- | ---------- | ------------------- |
| 2619 ms          | 4380 ms     | 18732 ms   | 6097 ms             |
```