### PR TITLE
prevent version mismatch for puppeteer chrome install on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           cache: pnpm
       - run: pnpm i --frozen-lockfile
-      - run: pnpm dlx puppeteer browsers install chrome
+      - run: pnpm puppeteer browsers install chrome
       - run: pnpm run test


### PR DESCRIPTION
If we use `pnpm dlx puppeteer` it will likely install the latest puppeteer version rather than use the local version that is in our package.json 👍 