### PR TITLE
stop running renovate on unpublished test app

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchFiles": ["test-ember-app/package.json"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate is noisy enough that we shouldn't be running it on an unpublished test app

Recommendation from this answer: https://github.com/renovatebot/renovate/discussions/20544#discussioncomment-5065648